### PR TITLE
型定義の修正

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,15 +1,16 @@
 import '../styles/global.css';
 import { FunctionComponent, useState } from "react";
 
-interface SquareProps {
-  value: string | null;
+type Mark = 'X' | 'O' | null;
+type SquareProps = {
+  value: Mark;
   onSquareClick: () => void;
 }
 
-interface BoardProps {
+type BoardProps = {
   xIsNext: boolean;
-  squares: string[];
-  onPlay: (nextSquares: string[]) => void;
+  squares: Array<Mark>;
+  onPlay: (nextSquares: Array<Mark>) => void;
 }
 
 const Square: FunctionComponent<SquareProps> = ({ value, onSquareClick }: SquareProps) => {
@@ -21,7 +22,7 @@ const Square: FunctionComponent<SquareProps> = ({ value, onSquareClick }: Square
 }
 
 const Board: FunctionComponent<BoardProps> = ({ xIsNext, squares, onPlay }: BoardProps) => {
-  const calculateWinner = (squares: string[]) => {
+  const calculateWinner = (squares: Array<Mark>) => {
     const lines = [
       [0, 1, 2],
       [3, 4, 5],
@@ -49,7 +50,7 @@ const Board: FunctionComponent<BoardProps> = ({ xIsNext, squares, onPlay }: Boar
     if (calculateWinner(squares) || squares[i]) {
       return;
     }
-    const nextSquares = squares.slice();
+    const nextSquares: Array<Mark> = squares.slice();
     if (xIsNext) {
       nextSquares[i] = "X";
     } else {
@@ -95,7 +96,7 @@ export default function Game() {
   const xIsNext = currentMove % 2 === 0;
   const currentSquares = history[currentMove];
 
-  const handlePlay = (nextSquares: string[]) => {
+  const handlePlay = (nextSquares: Array<Mark>) => {
     const nextHistory = [...history.slice(0, currentMove + 1), nextSquares];
     setHistory(nextHistory);
     setCurrentMove(nextHistory.length - 1);


### PR DESCRIPTION
## 修正点
- 型定義をinterfaceからtypeに変更
※ちなみにinterfaceを使っていた理由としては、ESLintのv6からはデフォルトでinterfaceを推奨するようになっていたからです。
- オブジェクト型からさらに厳密なリテラル型を格納した型エイリアスに変更し、該当する箇所に全て適用。

## 備忘録: Asanaで西村さんからいただいたレビュー内容
型なんですが、string, number等のプリミティブな型から更に限定出来る場合はしておいた方がより良いです。（例：↓）
![image](https://github.com/user-attachments/assets/89dfdac2-634d-4546-9353-f4daa5c008cb)

それと、基本的にはinterfaceではなくtypeを使って下さい。(クラス拡張などで必要な場合はinterface)