### PR TITLE
引き分け処理の実装

### DIFF
--- a/components/Board/index.tsx
+++ b/components/Board/index.tsx
@@ -1,8 +1,17 @@
 import { FunctionComponent } from 'react';
-import { Mark, Coordinates, BoardProps } from '../../types/index';
+import { Mark, Coordinates } from '../../types/index';
 import { Square } from '../Square';
 import { css, ClassNames } from '@emotion/react';
 import { status, boardRow, boardRow3x3, boardRow4x4 } from './styled';
+
+export type BoardProps = {
+  xIsNext: boolean;
+  squares: Mark[];
+  lines: number[][];
+  boardSize: number;
+  isDraw: boolean;
+  handlePlay: (nextSquares: Mark[], coordinates: Coordinates) => void;
+};
 
 export const Board: FunctionComponent<BoardProps> = ({
   xIsNext,

--- a/components/Board/index.tsx
+++ b/components/Board/index.tsx
@@ -9,6 +9,7 @@ export const Board: FunctionComponent<BoardProps> = ({
   squares,
   lines,
   boardSize,
+  isDraw,
   handlePlay,
 }: BoardProps) => {
   let winnersSquares: boolean[] = Array(boardSize ** 2).fill(false);
@@ -34,7 +35,7 @@ export const Board: FunctionComponent<BoardProps> = ({
   };
 
   const handleClick = (i: number) => {
-    if (calculateWinner(squares) || squares[i]) {
+    if (calculateWinner(squares) || isDraw || squares[i]) {
       return;
     }
     const nextSquares: Mark[] = squares.slice();
@@ -47,9 +48,11 @@ export const Board: FunctionComponent<BoardProps> = ({
   };
 
   const winner = calculateWinner(squares);
-  let status;
+  let status: string;
   if (winner) {
     status = 'Winner: ' + winner;
+  } else if (isDraw) {
+    status = 'Draw';
   } else {
     status = 'Next player: ' + (xIsNext ? 'X' : 'O');
   }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -61,6 +61,7 @@ export default function Game() {
     if (!checkDraw.includes(false)) {
       setIsDraw(true);
     }
+    // NOTE: Print Debug
     console.log(isDraw);
   }, [currentSquares, lines]);
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,6 +15,7 @@ export default function Game() {
   const currentSquares = history[currentMove]?.squares;
 
   let lines: number[][] = [];
+  const [isDraw, setIsDraw] = useState<boolean>(false);
 
   if (boardSize === 3) {
     lines = [
@@ -41,6 +42,27 @@ export default function Game() {
       [3, 6, 9, 12],
     ];
   }
+
+  useEffect(() => {
+    const checkDraw = lines.map((line) => {
+      const [a, b, c, d] = line;
+
+      const squareA = currentSquares[a];
+      const squareB = currentSquares[b];
+      const squareC = currentSquares[c];
+      const squareD = d === undefined ? null : currentSquares[d];
+
+      const containX = [squareA, squareB, squareC, squareD].includes('X');
+      const containO = [squareA, squareB, squareC, squareD].includes('O');
+
+      return containX && containO;
+    });
+
+    if (!checkDraw.includes(false)) {
+      setIsDraw(true);
+    }
+    console.log(isDraw);
+  }, [currentSquares, lines]);
 
   const handlePlay = (nextSquares: Mark[], nextCoordinates: Coordinates) => {
     const nextHistory = [
@@ -98,6 +120,7 @@ export default function Game() {
           squares={currentSquares || []}
           lines={lines}
           boardSize={boardSize}
+          isDraw={isDraw}
           handlePlay={handlePlay}
         />
       </div>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -61,7 +61,7 @@ export default function Game() {
     if (!checkDraw.includes(false)) {
       setIsDraw(true);
     }
-    // NOTE: Print Debug
+    //! NOTE: Print Debug
     console.log(isDraw);
   }, [currentSquares, lines]);
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -61,8 +61,6 @@ export default function Game() {
     if (!checkDraw.includes(false)) {
       setIsDraw(true);
     }
-    //! NOTE: Print Debug
-    console.log(isDraw);
   }, [currentSquares, lines]);
 
   const handlePlay = (nextSquares: Mark[], nextCoordinates: Coordinates) => {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -73,6 +73,7 @@ export default function Game() {
   };
 
   const jumpTo = (nextMove: number) => {
+    setIsDraw(false);
     setCurrentMove(nextMove);
   };
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -7,5 +7,6 @@ export type BoardProps = {
   squares: Mark[];
   lines: number[][];
   boardSize: number;
+  isDraw: boolean;
   handlePlay: (nextSquares: Mark[], coordinates: Coordinates) => void;
 };

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,12 +1,3 @@
 export type Mark = 'X' | 'O' | null;
 
 export type Coordinates = { x: number; y: number } | null;
-
-export type BoardProps = {
-  xIsNext: boolean;
-  squares: Mark[];
-  lines: number[][];
-  boardSize: number;
-  isDraw: boolean;
-  handlePlay: (nextSquares: Mark[], coordinates: Coordinates) => void;
-};


### PR DESCRIPTION
## 変更点
- 3x3, 4x4で引き分けが決まった場合の判定処理の実装。
- 型定義BoardPropsをBoard/index.tsxに移動。
- Drawになった後にGo to moveを押しても前の盤面に戻れるよう修正。